### PR TITLE
Now using port 5001 instead of 5000

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ push-images:
 		--amend davidzajac1/zillacode-backend:amd64 \
 		--amend davidzajac1/zillacode-backend:arm64
 	docker manifest push davidzajac1/zillacode-backend:latest
-	@echo "Building and pushing backend to Docker Hub"
+	@echo "Building and pushing db-service to Docker Hub"
 	docker build --platform linux/arm64 -t davidzajac1/zillacode-db-service:arm64 .
 	docker push davidzajac1/zillacode-db-service:arm64
 	docker build --platform linux/amd64 -t davidzajac1/zillacode-db-service:amd64 .
@@ -50,7 +50,7 @@ push-images:
 		--amend davidzajac1/zillacode-db-service:amd64 \
 		--amend davidzajac1/zillacode-db-service:arm64
 	docker manifest push davidzajac1/zillacode-db-service:latest
-	@echo "Building and pushing backend to Docker Hub"
+	@echo "Building and pushing frontend to Docker Hub"
 	docker build --platform linux/arm64 -t davidzajac1/zillacode-frontend:arm64 .
 	docker push davidzajac1/zillacode-frontend:arm64
 	docker build --platform linux/amd64 -t davidzajac1/zillacode-frontend:amd64 .
@@ -59,7 +59,7 @@ push-images:
 		--amend davidzajac1/zillacode-frontend:amd64 \
 		--amend davidzajac1/zillacode-frontend:arm64
 	docker manifest push davidzajac1/zillacode-frontend:latest
-	@echo "Building and pushing backend to Docker Hub"
+	@echo "Building and pushing scala-spark to Docker Hub"
 	docker build --platform linux/arm64 -t davidzajac1/zillacode-scala-spark:arm64 .
 	docker push davidzajac1/zillacode-scala-spark:arm64
 	docker build --platform linux/amd64 -t davidzajac1/zillacode-scala-spark:amd64 .
@@ -68,7 +68,7 @@ push-images:
 		--amend davidzajac1/zillacode-scala-spark:amd64 \
 		--amend davidzajac1/zillacode-scala-spark:arm64
 	docker manifest push davidzajac1/zillacode-scala-spark:latest
-	@echo "Building and pushing backend to Docker Hub"
+	@echo "Building and pushing spark to Docker Hub"
 	docker build --platform linux/arm64 -t davidzajac1/zillacode-spark:arm64 .
 	docker push davidzajac1/zillacode-spark:arm64
 	docker build --platform linux/amd64 -t davidzajac1/zillacode-spark:amd64 .

--- a/README.md
+++ b/README.md
@@ -16,12 +16,21 @@ In addition to solving Zillacode problems you can also learn from the repo itsel
 ### Run Locally
 
 ```bash
-$ git clone https://github.com/davidzajac1/zillacode.git
-$ cd zillacode
-$ docker-compose up
+git clone https://github.com/davidzajac1/zillacode.git
+cd zillacode
+docker-compose up
 ```
 
 Then navigate to [http://localhost:5173](http://localhost:5173)
+
+**NOTE** Make sure nothing is running on ports 5001, 5173, 8001, 8002, 8003 before running locally. See the commands below to kill anything running on these ports:
+
+```bash
+# Mac/Linux
+sudo kill -9 $(sudo lsof -ti:5001,5173,8001,8002,8003)
+# Windows
+netstat -ano | findstr :5001 :5173 :8001 :8002 :8003
+```
 
 ### Optional - Configuring Snowflake
 
@@ -71,7 +80,7 @@ To make a Pull Request fork the project then make a Pull Request to the `master`
 
 ### Frontend
 
-For making frontend changes, spin up the backend in the background using Docker by running `make up-backend`, this will spin up the backend on http://localhost:5000. Then run `make serve-frontend` to serve the frontend on http://localhost:3000. The frontend will send requests to the backend hosted locally.
+For making frontend changes, spin up the backend in the background using Docker by running `make up-backend`, this will spin up the backend on http://localhost:5000. Then run `make serve-frontend` to serve the frontend on http://localhost:5173. The frontend will send requests to the backend hosted locally.
 
 For adding new dependencies run `make add package=<PACKAGE TO INSTALL>`.
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ sudo kill -9 $(sudo lsof -ti:5001,5173,8001,8002,8003)
 netstat -ano | findstr :5001 :5173 :8001 :8002 :8003
 ```
 
+Zillacode previously used port 5000 which caused issues for many users and thus now uses port 5001 instead. If you are experiencing issues like problems endlessly loading please make sure you are using newest version of the `master` branch and the newest image from the [zillacode-frontend](https://hub.docker.com/r/davidzajac1/zillacode-frontend) Docker Hub repo and that you have inspected the IDE page to make sure there are no requests going to port 5000.
+
 ### Optional - Configuring Snowflake
 
 Note Snowflake is not Open Source thus to solve problems with DBT/Snowflake you need to add a `.env` file with Snowflake credentials in the `backend` directory. All problems except for DBT/Snowflake problem will work normally without the `.env` file.

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,7 +1,7 @@
 services:
   backend:
     ports:
-      - 5000:5000
+      - 5001:5000
     build: ./backend
     extra_hosts:
       - host.docker.internal:host-gateway

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ services:
   backend:
     image: davidzajac1/zillacode-backend:latest
     ports:
-      - 5000:5000
+      - 5001:5000
     extra_hosts:
       - host.docker.internal:host-gateway
     networks:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "cross-env NODE_OPTIONS='--inspect' VITE_PUBLIC_API_BASE=http://localhost:5000 vite --host",
+    "test": "cross-env NODE_OPTIONS='--inspect' VITE_PUBLIC_API_BASE=http://localhost:5001 vite --host",
     "build": "vite build",
     "preview": "vite preview",
     "cypress": "cross-env CYPRESS_BASE_URL='http://localhost:5173' cypress open"


### PR DESCRIPTION
Many users have been having issues spinning up Zillacode locally because they are already running an important process on their machine that uses port 5000. With these changes the backend container now runs on port 5001 instead. 

The frontend container has been changed to send requests to port 5001. These changes have already been pushed to the [zillacode-frontend](https://hub.docker.com/r/davidzajac1/zillacode-frontend) Docker Hub repo.

These changes should solve issue #8.